### PR TITLE
Detect cookie recipe tampering

### DIFF
--- a/clusters/bakery0/falco/helm.yaml
+++ b/clusters/bakery0/falco/helm.yaml
@@ -19,6 +19,14 @@ spec:
     falco:
       syscallEventDrops:
         actions: []
+    customRules:
+      cookierules.yaml: |+
+        - rule: Cookie recipes tampering detector
+          desc: Detect tampering of super precious cookie recipes
+          condition: ((evt.type=open or evt.type=openat) and fd.name startswith '/usr/share/nginx') or (modify and evt.arg.oldpath startswith '/usr/share/nginx') or (modify and evt.arg.path startswith '/usr/share/nginx') or (modify and fd.name startswith '/usr/share/nginx') or (modify and evt.arg.name startswith '/usr/share/nginx')
+          output: Cookie recipes tampering detected, secure your cookies, make an espresso and eat all of them if necessary. No one can have them. (uid=%user.uid container_id=%container.id container_name=%container.name image=%container.image.repository:%container.image.tag oldpath=%evt.arg.oldpath path=%evt.arg.path fd.name=%fd.name name=%evt.arg.name)
+          priority: WARNING
+          tags: [importantrecipesalert]
 
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta1


### PR DESCRIPTION
We really want to make sure no one is tampering our precious recipe. It would be very bad for our users to get a fake rule. Eating the right cookies is SO important.


Co-Authored-By: Lorenzo Fontana <lo@linux.com>
Signed-off-by: leigh capili <leigh@null.net>